### PR TITLE
Use new mainnet registry due to security vuln

### DIFF
--- a/lib/network-map.json
+++ b/lib/network-map.json
@@ -1,6 +1,6 @@
 {
   "1": {
-    "registry": "314159265dd8dbb310642f98f50c066173c1259b"
+    "registry": "00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
   },
   "3": {
     "registry": "112234455c3a32fd11230c42e7bccd4a84e02010",


### PR DESCRIPTION
Use new registry based on the new security vulnerability that was disclosed today. https://github.com/ensdomains/ens/security/advisories/GHSA-8f9f-pc5v-9r5h